### PR TITLE
I think changing GET to HEAD might cause problem

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -401,12 +401,10 @@ typedef enum {
     NSString *eTag = [headers objectForKey:@"ETag"];
     
     if(lastModified) {
-        [self.request setHTTPMethod:@"HEAD"];
         [self.request addValue:lastModified forHTTPHeaderField:@"IF-MODIFIED-SINCE"];
     }
     
     if(eTag) {
-        [self.request setHTTPMethod:@"HEAD"];
         [self.request addValue:eTag forHTTPHeaderField:@"IF-NONE-MATCH"];
     }    
 }


### PR DESCRIPTION
According to rfc2616(http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html), HEAD request should not return message body and GET request should not return message body if "If-None-Match" condition is true.

So I think the change of http method is unnecessary and might get no data on servers that return empty content for HEAD request.
