### PR TITLE
Redeclare cacheData variable results in NSData object with 0 bytes

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -297,7 +297,7 @@ static NSOperationQueue *_sharedNetworkQueue;
     
     if([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
         
-        NSData *cachedData = [NSData dataWithContentsOfFile:filePath];
+        cachedData = [NSData dataWithContentsOfFile:filePath];
         [self saveCacheData:cachedData forKey:[operation uniqueIdentifier]]; // bring it back to the in-memory cache
         return cachedData;
     }


### PR DESCRIPTION
In MKNetworkEngine.m on line 300, you redeclare cacheData as another NSData. This in turn means that when you call [NSData dataWithContentsOfFile:], it initializes, but returns 0 bytes. By simply removing the declaration, caching works as it should.
