### PR TITLE
Added onNotModified method for MKNetworkOperation

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -39,7 +39,6 @@ typedef void (^MKNKImageBlock) (UIImage* fetchedImage, NSURL* url, BOOL isInCach
 typedef void (^MKNKImageBlock) (NSImage* fetchedImage, NSURL* url, BOOL isInCache);
 #endif
 typedef void (^MKNKErrorBlock)(NSError* error);
-typedef void (^MKNKNotModifiedBlock)();
 
 typedef void (^MKNKAuthBlock)(NSURLAuthenticationChallenge* challenge);
 
@@ -341,7 +340,7 @@ typedef enum {
  *  Instead, this block will get called.
  *  
  */
--(void) onNotModified:(MKNKNotModifiedBlock) notModifiedBlock;
+-(void) onNotModified:(MKNKResponseBlock) notModifiedBlock;
 
 /*!
  *  @abstract Block Handler for tracking upload progress
@@ -476,6 +475,8 @@ typedef enum {
  *
  */
 -(void) operationSucceeded;
+
+-(void) operationNotModified;
 
 /*!
  *  @abstract Overridable custom method where you can add your custom business logic error handling

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -433,7 +433,7 @@
     [self.errorBlocks addObject:[error copy]];
 }
 
--(void) onNotModified:(MKNKNotModifiedBlock) notModifiedBlock {
+-(void) onNotModified:(MKNKResponseBlock) notModifiedBlock {
     
     [self.notModifiedBlocks addObject:[notModifiedBlock copy]];
 }
@@ -1055,9 +1055,7 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
         }
         else if(self.response.statusCode == 304) {
             DLog(@"%@ not modified", self.url);
-            
-            for(MKNKNotModifiedBlock notModifiedBlock in self.notModifiedBlocks)
-                notModifiedBlock();
+            [self operationNotModified];
         }
         else if(self.response.statusCode == 307) {
             DLog(@"%@ temporarily redirected", self.url);
@@ -1142,6 +1140,11 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
     
     for(MKNKResponseBlock responseBlock in self.responseBlocks)
         responseBlock(self);
+}
+
+-(void) operationNotModified {
+    for(MKNKResponseBlock notModifiedBlock in self.notModifiedBlocks)
+        notModifiedBlock(self);
 }
 
 -(void) operationFailedWithError:(NSError*) error {


### PR DESCRIPTION
Added onNotModified method for MKNetworkOperation, which allows a block to be executed when a server responds with HTTP 304 (not modified). 

This is useful for occasions when we want to refresh some data and have there be some sort of notification when the server has responded, even if it is only with a 304 (e.g., Pull to Refresh). 

The alternative to this would be to have something like completedOperation.isNotModifiedResponse (similar to completedOperation.isCachedResponse).
