### PR TITLE
Made the HTTP header matching case insensitive

### DIFF
--- a/MKNetworkKit-iOS/MKNetworkKit-iOS.xcodeproj/project.pbxproj
+++ b/MKNetworkKit-iOS/MKNetworkKit-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8B97038C14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B97038A14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.h */; };
+		8B97038D14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B97038B14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.m */; };
 		AB3A308A148F099C00D06246 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB3A3089148F099C00D06246 /* Security.framework */; };
 		AB3A3098148F0A3B00D06246 /* NSDate+RFC1123.h in Headers */ = {isa = PBXBuildFile; fileRef = AB3A3096148F0A3B00D06246 /* NSDate+RFC1123.h */; };
 		AB3A3099148F0A3B00D06246 /* NSDate+RFC1123.m in Sources */ = {isa = PBXBuildFile; fileRef = AB3A3097148F0A3B00D06246 /* NSDate+RFC1123.m */; };
@@ -31,6 +33,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		8B97038A14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+CaseInsensitive.h"; sourceTree = "<group>"; };
+		8B97038B14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+CaseInsensitive.m"; sourceTree = "<group>"; };
 		AB3A3089148F099C00D06246 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		AB3A3096148F0A3B00D06246 /* NSDate+RFC1123.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+RFC1123.h"; sourceTree = "<group>"; };
 		AB3A3097148F0A3B00D06246 /* NSDate+RFC1123.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+RFC1123.m"; sourceTree = "<group>"; };
@@ -131,6 +135,8 @@
 				ABDC97451498A6DE0034CEBE /* NSData+Base64.m */,
 				ABB5C2AA148B3B360056D3E9 /* NSDictionary+RequestEncoding.h */,
 				ABB5C2AB148B3B360056D3E9 /* NSDictionary+RequestEncoding.m */,
+				8B97038A14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.h */,
+				8B97038B14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.m */,
 				ABB5C2AC148B3B360056D3E9 /* NSString+MKNetworkKitAdditions.h */,
 				ABB5C2AD148B3B360056D3E9 /* NSString+MKNetworkKitAdditions.m */,
 				ABB5C2AE148B3B360056D3E9 /* UIAlertView+MKNetworkKitAdditions.h */,
@@ -174,6 +180,7 @@
 				ABB5C2C4148B3B360056D3E9 /* Reachability.h in Headers */,
 				AB3A3098148F0A3B00D06246 /* NSDate+RFC1123.h in Headers */,
 				ABDC97461498A6DE0034CEBE /* NSData+Base64.h in Headers */,
+				8B97038C14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -236,6 +243,7 @@
 				ABB5C2C5148B3B360056D3E9 /* Reachability.m in Sources */,
 				AB3A3099148F0A3B00D06246 /* NSDate+RFC1123.m in Sources */,
 				ABDC97471498A6DE0034CEBE /* NSData+Base64.m in Sources */,
+				8B97038D14BD7EC60047D1A2 /* NSDictionary+CaseInsensitive.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MKNetworkKit/Categories/NSDictionary+CaseInsensitive.h
+++ b/MKNetworkKit/Categories/NSDictionary+CaseInsensitive.h
@@ -1,0 +1,47 @@
+//
+//  NSDictionary+CaseInsensitive.h
+//
+//  Copyright (C) 2012 Chris Brauchli
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+/// Utility for building case-insensitive NSDictionary objects.
+@interface NSDictionary (NSDictionaryCaseInsensitiveAdditions)
+
+/// Initializes an NSDictionary with a case-insensitive comparison function
+/// for NSString keys, while non-NSString keys are treated normally.
+///
+/// The case for NSString keys is preserved, though duplicate keys (when
+/// compared in a case-insensitive fashion) have one of their values dropped
+/// arbitrarily.
+///
+/// An example of use with HTTP headers in an NSHTTPURLResponse object:
+///
+/// NSDictionary *headers =
+///     [NSDictionary dictionaryWithDictionaryCaseInsensitive:
+///      [response allHeaderFields]];
+/// NSString *contentType = [headers objectForKey:@"Content-Type"];
+- (id)initWithDictionaryCaseInsensitive:(NSDictionary *)dictionary;
+
+/// Returns a newly created and autoreleased NSDictionary object as above.
++ (id)dictionaryWithDictionaryCaseInsensitive:(NSDictionary *)dictionary;
+
+@end

--- a/MKNetworkKit/Categories/NSDictionary+CaseInsensitive.m
+++ b/MKNetworkKit/Categories/NSDictionary+CaseInsensitive.m
@@ -1,0 +1,66 @@
+//
+//  NSDictionary+CaseInsensitive.m
+//
+//  Copyright (C) 2012 Chris Brauchli
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import "NSDictionary+CaseInsensitive.h"
+
+static Boolean caseInsensitiveEqual (const void *a, const void *b)
+{
+    return [(__bridge id)a compare:(__bridge id)b options:
+            NSCaseInsensitiveSearch | NSLiteralSearch] == NSOrderedSame;
+}
+
+static CFHashCode caseInsensitiveHash (const void *value)
+{
+    return [[(__bridge id)value lowercaseString] hash];
+}
+
+@implementation NSDictionary (NSDictionaryCaseInsensitiveAdditions)
+
+- (id)initWithDictionaryCaseInsensitive:(NSDictionary *)src
+{
+    CFDictionaryKeyCallBacks keyCallbacks = kCFTypeDictionaryKeyCallBacks;
+    keyCallbacks.equal = caseInsensitiveEqual;
+    keyCallbacks.hash = caseInsensitiveHash;
+    
+    CFMutableDictionaryRef dest = CFDictionaryCreateMutable (kCFAllocatorDefault,
+                                                             [src count], // capacity
+                                                             &keyCallbacks,
+                                                             &kCFTypeDictionaryValueCallBacks
+                                                             );
+    
+    NSEnumerator *enumerator = [src keyEnumerator];
+    id key = nil;
+    while (key = [enumerator nextObject]) {
+        id value = [src objectForKey:key];
+        [(__bridge NSMutableDictionary *)dest setObject:value forKey:key];
+    }
+    
+    return (__bridge NSDictionary *)dest;
+}
+
++ (id)dictionaryWithDictionaryCaseInsensitive:(NSDictionary *)dictionary
+{
+    return [[self alloc] initWithDictionaryCaseInsensitive:dictionary];
+}
+
+@end

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -25,6 +25,7 @@
 
 #import "MKNetworkOperation.h"
 #import "NSDictionary+RequestEncoding.h"
+#import "NSDictionary+CaseInsensitive.h"
 #import "NSString+MKNetworkKitAdditions.h"
 
 
@@ -911,7 +912,7 @@
     for(NSOutputStream *stream in self.downloadStreams)
         [stream open];
     
-    NSDictionary *httpHeaders = [self.response allHeaderFields];
+    NSDictionary *httpHeaders = [NSDictionary dictionaryWithDictionaryCaseInsensitive:[self.response allHeaderFields]];
     
     if([self.request.HTTPMethod isEqualToString:@"GET"]) {
         


### PR DESCRIPTION
I've noticed that some servers return ETag headers with name "Etag," "ETag," "ETAG", etc. all of which do not get matched by NSDictionary's "objectForKey" method, which is case sensitive. HTTP header names are case insensitive. This commit allows case insensitive matching.
