### PR TITLE
Authentication fixes (issue #35, issue #37)

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -437,7 +437,7 @@ static NSOperationQueue *_sharedNetworkQueue;
     
     [self.memoryCacheKeys insertObject:cacheDataKey atIndex:0]; // remove it and insert it at start
     
-    if([self.memoryCacheKeys count] > [self cacheMemoryCost])
+    if([self.memoryCacheKeys count] >= [self cacheMemoryCost])
     {
         NSString *lastKey = [self.memoryCacheKeys lastObject];        
         NSData *data = [self.memoryCache objectForKey:lastKey];        

--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -267,6 +267,15 @@ typedef enum {
 @property (copy, nonatomic) void (^operationStateChangedHandler)(MKNetworkOperationState newState);
 
 /*!
+ *  @abstract controls persistence of authentication credentials
+ *  @property credentialPersistence
+ *  
+ *  @discussion
+ *  The default value is set to NSURLCredentialPersistenceForSession, change it to NSURLCredentialPersistenceNon to avoid caching issues (isse #35)
+ */
+@property (nonatomic, assign) NSURLCredentialPersistence credentialPersistence;
+
+/*!
  *  @abstract Add additional header parameters
  *  
  *  @discussion

--- a/iOS-Demo/MKNetworkKitDemo/AppDelegate.m
+++ b/iOS-Demo/MKNetworkKitDemo/AppDelegate.m
@@ -54,6 +54,7 @@
     self.sampleDownloader = [[ExampleDownloader alloc] initWithHostName:nil customHeaderFields:nil];
     self.samplePoster = [[ExamplePost alloc] initWithHostName:@"thgame.phpfog.com" customHeaderFields:nil];
     self.sampleAuth = [[AuthTestEngine alloc] initWithHostName:@"api.mk.sg" customHeaderFields:nil];
+    [self.sampleAuth useCache];
     
     return YES;
 }

--- a/iOS-Demo/MKNetworkKitDemo/AuthTestEngine.h
+++ b/iOS-Demo/MKNetworkKitDemo/AuthTestEngine.h
@@ -10,5 +10,7 @@
 
 -(void) basicAuthTest;
 -(void) digestAuthTest;
+-(void)digestAuthTestWithUser:(NSString*)username password:(NSString*)password;
 -(void) clientCertTest;
+-(int) cacheMemoryCost;
 @end

--- a/iOS-Demo/MKNetworkKitDemo/AuthTestEngine.m
+++ b/iOS-Demo/MKNetworkKitDemo/AuthTestEngine.m
@@ -47,6 +47,25 @@
     [self enqueueOperation:op];
 }
 
+-(void)digestAuthTestWithUser:(NSString*)username password:(NSString*)password {
+    MKNetworkOperation *op = [self operationWithURLString:@"http://teeqemm.dnsalias.org:82/Users/11220/Catalogs/"
+                                              params:nil 
+                                          httpMethod:@"GET"];
+    
+    [op setUsername:username password:password];
+    [op setCredentialPersistence:NSURLCredentialPersistenceNone];
+    
+    [op onCompletion:^(MKNetworkOperation *operation) {
+        
+        DLog(@"%@", [operation responseString]); 
+    } onError:^(NSError *error) {
+        
+        DLog(@"%@", [error localizedDescription]);         
+    }];
+    [self enqueueOperation:op];
+}
+
+
 -(void) clientCertTest {
     
     MKNetworkOperation *op = [self operationWithPath:@"mknetworkkit/client_auth.php"
@@ -66,4 +85,9 @@
     }];
     [self enqueueOperation:op];
 }
+
+-(int) cacheMemoryCost {
+    return 0;
+}
+
 @end

--- a/iOS-Demo/MKNetworkKitDemo/ViewController.h
+++ b/iOS-Demo/MKNetworkKitDemo/ViewController.h
@@ -33,5 +33,7 @@
 
 @property (nonatomic, weak) IBOutlet UIProgressView *downloadProgessBar;
 @property (nonatomic, weak) IBOutlet UIProgressView *uploadProgessBar;
+@property (nonatomic, weak) IBOutlet UITextField *userTextField;
+@property (nonatomic, weak) IBOutlet UITextField *passwordTextField;
 
 @end

--- a/iOS-Demo/MKNetworkKitDemo/ViewController.m
+++ b/iOS-Demo/MKNetworkKitDemo/ViewController.m
@@ -34,6 +34,8 @@
 
 @synthesize downloadProgessBar = _downloadProgessBar;
 @synthesize uploadProgessBar = _uploadProgessBar;
+@synthesize userTextField = _userTextField;
+@synthesize passwordTextField = _passwordTextField;
 
 - (void)didReceiveMemoryWarning
 {
@@ -171,6 +173,7 @@
     
     //[ApplicationDelegate.sampleAuth basicAuthTest];
     //[ApplicationDelegate.sampleAuth digestAuthTest];
-    [ApplicationDelegate.sampleAuth clientCertTest];
+    [ApplicationDelegate.sampleAuth digestAuthTestWithUser:self.userTextField.text password:self.passwordTextField.text];
+    //[ApplicationDelegate.sampleAuth clientCertTest];
 }
 @end

--- a/iOS-Demo/MKNetworkKitDemo/en.lproj/MainStoryboard.storyboard
+++ b/iOS-Demo/MKNetworkKitDemo/en.lproj/MainStoryboard.storyboard
@@ -14,7 +14,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Xhr-JR-Dgb">
-                                <rect key="frame" x="85" y="57" width="151" height="37"/>
+                                <rect key="frame" x="20" y="57" width="151" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                 <state key="normal" title="Convert Currency">
@@ -81,7 +81,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Axl-TC-OtQ">
-                                <rect key="frame" x="20" y="134" width="136" height="37"/>
+                                <rect key="frame" x="179" y="57" width="136" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                 <state key="normal" title="Test Post">
@@ -96,7 +96,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8Fc-e9-wj7">
-                                <rect key="frame" x="164" y="134" width="136" height="37"/>
+                                <rect key="frame" x="179" y="102" width="136" height="70"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                 <state key="normal" title="Test Auth">
@@ -110,13 +110,27 @@
                                     <action selector="testAuthTapped:" destination="2" eventType="touchUpInside" id="aXy-Rn-hqI"/>
                                 </connections>
                             </button>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="username" minimumFontSize="17" id="RTo-3I-DXZ">
+                                <rect key="frame" x="20" y="102" width="151" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="password" minimumFontSize="17" id="yEM-GJ-ODv">
+                                <rect key="frame" x="20" y="141" width="151" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
                         </subviews>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="downloadProgessBar" destination="JgO-2H-s3n" id="OdQ-cT-7Aq"/>
+                        <outlet property="passwordTextField" destination="yEM-GJ-ODv" id="IVm-Bp-EuA"/>
                         <outlet property="uploadProgessBar" destination="2bg-jm-Swi" id="HCu-Pv-t3d"/>
+                        <outlet property="userTextField" destination="RTo-3I-DXZ" id="ODo-N6-qAE"/>
                     </connections>
                 </viewController>
             </objects>
@@ -126,9 +140,10 @@
         <class className="ViewController" superclassName="UIViewController">
             <source key="sourceIdentifier" type="project" relativePath="./Classes/ViewController.h"/>
             <relationships>
-                <relationship kind="action" name="testAuthTapped:"/>
                 <relationship kind="outlet" name="downloadProgessBar" candidateClass="UIProgressView"/>
+                <relationship kind="outlet" name="passwordTextField" candidateClass="UITextField"/>
                 <relationship kind="outlet" name="uploadProgessBar" candidateClass="UIProgressView"/>
+                <relationship kind="outlet" name="userTextField" candidateClass="UITextField"/>
             </relationships>
         </class>
     </classes>


### PR DESCRIPTION
- self.requests cachePolicy changed to
  NSURLRequestReloadIgnoringLocalCacheData (issue #35, issue #37)
- caching of authentication credentials can be controlled via property
  credentialPersistence (issue #35)
- connection:willSendRequestForAuthenticationChallenge: sends
  credentials only once, then continues without credentials to trigger
  NSURLErrorDomain error 401 (issue #37)
- cacheMemoryCost can be set to 0 to stop memory caching.
