### PR TITLE
URLEncode method should not percent encode the tilde (˜) character

### DIFF
--- a/MKNetworkKit/Categories/NSString+MKNetworkKitAdditions.m
+++ b/MKNetworkKit/Categories/NSString+MKNetworkKitAdditions.m
@@ -55,7 +55,7 @@
     CFStringRef encodedCFString = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, 
                                                                         (__bridge CFStringRef) self, 
                                                                         nil,
-                                                                        CFSTR("?!@#$^&%*+,:;='\"`<>()[]{}/\\|~ "), 
+                                                                        CFSTR("?!@#$^&%*+,:;='\"`<>()[]{}/\\| "), 
                                                                         kCFStringEncodingUTF8);
     
     NSString *encodedString = [[NSString alloc] initWithString:(__bridge_transfer NSString*) encodedCFString];    


### PR DESCRIPTION
According to RFC 5849 (page 28), the tilde (~) character should not be percent encoded. Thanks Eric Mulder for pointing this out.

Ref: http://tools.ietf.org/html/rfc5849#page-28
