### PR TITLE
API to handle "operation already queued" situations

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -33,6 +33,7 @@ typedef enum {
 
 typedef void (^MKNKProgressBlock)(double progress);
 typedef void (^MKNKResponseBlock)(MKNetworkOperation* completedOperation);
+typedef void (^MKNKAlreadyQueuedBlock)(MKNetworkOperation *queuedOperation);
 #if TARGET_OS_IPHONE
 typedef void (^MKNKImageBlock) (UIImage* fetchedImage, NSURL* url, BOOL isInCache);
 #elif TARGET_OS_MAC
@@ -361,7 +362,7 @@ typedef enum {
  *  handler was invoked with a cached data or with real data by calling the isCachedResponse method.
  *
  *  @seealso
- *  isCachedResponse
+ *  isCachedResponse, onAlreadyQueued:
  */
 -(void) onCompletion:(MKNKResponseBlock) response onError:(MKNKErrorBlock) error;
 
@@ -384,6 +385,18 @@ typedef enum {
  *
  */
 -(void) onDownloadProgressChanged:(MKNKProgressBlock) downloadProgressBlock;
+
+/*!
+ *  @abstract Block Handler for when a given operation is already queued
+ *  
+ *  @discussion
+ *	This method can be used to handle situations when a given operation is already
+ *  enqueued. alreadyQueuedBlock is called from MKNetworkEngine's enqueueOperation:
+ *  when an operation is already present in the operation queue, and it takes
+ *  that already queued operation as a parameter.
+ *
+ */
+-(void) onAlreadyQueued:(MKNKAlreadyQueuedBlock) alreadyQueuedBlock;
 
 /*!
  *  @abstract Uploads a resource from a stream

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -43,6 +43,7 @@
 
 @property (nonatomic, strong) NSMutableArray *responseBlocks;
 @property (nonatomic, strong) NSMutableArray *errorBlocks;
+@property (nonatomic, strong) NSMutableArray *alreadyQueuedBlocks;
 
 @property (nonatomic, assign) MKNetworkOperationState state;
 @property (nonatomic, assign) BOOL isCancelled;
@@ -104,6 +105,7 @@
 
 @synthesize responseBlocks = _responseBlocks;
 @synthesize errorBlocks = _errorBlocks;
+@synthesize alreadyQueuedBlocks = _alreadyQueuedBlocks;
 
 @synthesize isCancelled = _isCancelled;
 @synthesize mutableData = _mutableData;
@@ -368,6 +370,7 @@
     [theCopy setClientCertificate:[self.clientCertificate copy]];
     [theCopy setResponseBlocks:[self.responseBlocks copy]];
     [theCopy setErrorBlocks:[self.errorBlocks copy]];
+    [theCopy setAlreadyQueuedBlocks:[self.alreadyQueuedBlocks copy]];
     [theCopy setState:self.state];
     [theCopy setIsCancelled:self.isCancelled];
     [theCopy setMutableData:[self.mutableData copy]];
@@ -396,6 +399,9 @@
     [self.uploadProgressChangedHandlers addObjectsFromArray:operation.uploadProgressChangedHandlers];
     [self.downloadProgressChangedHandlers addObjectsFromArray:operation.downloadProgressChangedHandlers];
     [self.downloadStreams addObjectsFromArray:operation.downloadStreams];
+
+    for(MKNKAlreadyQueuedBlock alreadyQueuedBlock in operation.alreadyQueuedBlocks)
+        alreadyQueuedBlock(self);
 }
 
 -(void) setCachedData:(NSData*) cachedData {
@@ -450,6 +456,10 @@
     [self.downloadProgressChangedHandlers addObject:[downloadProgressBlock copy]];
 }
 
+-(void) onAlreadyQueued:(MKNKAlreadyQueuedBlock)alreadyQueuedBlock {
+    [self.alreadyQueuedBlocks addObject:[alreadyQueuedBlock copy]];
+}
+
 -(void) setUploadStream:(NSInputStream*) inputStream {
     
 #warning Method not tested yet.
@@ -470,6 +480,7 @@
         
         self.responseBlocks = [NSMutableArray array];
         self.errorBlocks = [NSMutableArray array];        
+        self.alreadyQueuedBlocks = [NSMutableArray array];
         
         self.filesToBePosted = [NSMutableArray array];
         self.dataToBePosted = [NSMutableArray array];
@@ -822,6 +833,9 @@
     
     [self.errorBlocks removeAllObjects];
     self.errorBlocks = nil;
+    
+    [self.alreadyQueuedBlocks removeAllObjects];
+    self.alreadyQueuedBlocks = nil;
     
     [self.uploadProgressChangedHandlers removeAllObjects];
     self.uploadProgressChangedHandlers = nil;


### PR DESCRIPTION
- Added onAlreadyQueued: to MKNetworkOperation to specify
  block(s) to be executed when operation is re-enqueued.
- Defined MKNKAlreadyQueuedBlock which is an argument to
  onAlreadyQueued: and takes already queued operation as
  a parameter
- Documentation updated

---

Hi Mugunth,

In my application I need to increase network request's priority if it's re-enqueued.
I couldn't do it easily with current API, so I wrote this small addition.

It allows to specify actions to be executed when engine is trying to enqueue an operation that's already in the queue.
The alternative approach would be to advertise (allow in docs to override it) and maybe rename `updateHandlersFromOperation:` , or just create a separate method that's called from `updateHandlersFromOperation:`. I just went the way the API is constructed and defined handler blocks.

Feel free to merge it if you like, or suggest a better approach.

Cheers!
Dominik
