### PR TITLE
Making a 4xx response body available in the error handlers.

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -1181,10 +1181,11 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
     }
     
   } else if (self.response.statusCode >= 400 && self.response.statusCode < 600 && ![self isCancelled]) {                        
-    
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:self.response.allHeaderFields];
+    [userInfo setObject:self.responseString forKey:@"responseString"];
     [self operationFailedWithError:[NSError errorWithDomain:NSURLErrorDomain
                                                        code:self.response.statusCode
-                                                   userInfo:self.response.allHeaderFields]];
+                                                   userInfo:userInfo]];
   }  
   [self endBackgroundTask];
   


### PR DESCRIPTION
Some web services send a body on 4xx responses containing data about the error, how to fix it, etc. I need to access the response body in the error handlers. This patch allows that.
