### PR TITLE
Non-retained original queue

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -367,6 +367,7 @@ static NSOperationQueue *_sharedNetworkQueue;
   NSParameterAssert(operation != nil);
   // Grab on to the current queue (We need it later)
   dispatch_queue_t originalQueue = dispatch_get_current_queue();
+  dispatch_retain(originalQueue);
   // Jump off the main thread, mainly for disk cache reading purposes
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     [operation setCacheHandler:^(MKNetworkOperation* completedCacheableOperation) {
@@ -437,8 +438,7 @@ static NSOperationQueue *_sharedNetworkQueue;
     if([self.reachability currentReachabilityStatus] == NotReachable)
       [self freezeOperations];
   });
-  
-  
+  dispatch_release(originalQueue);
 }
 
 - (MKNetworkOperation*)imageAtURL:(NSURL *)url onCompletion:(MKNKImageBlock) imageFetchedBlock


### PR DESCRIPTION
When enqueueOperation: is called from an ephemeral queue, the calling queue be kept alive (retained) so that the response can be processed in that queue.

At present, if the queue used to call enqueueOperation: is freed by the system, the pointer originalQueue points to an invalid queue. ARC does not handle these situations. The problem can not be reproduced all the times, because it is a run condition (it sometimes works because the pointer is still valid).

Attaching a pull request to fix it.
