### PR TITLE
fixing fix:dispatch_release in the correct place

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -437,8 +437,8 @@ static NSOperationQueue *_sharedNetworkQueue;
 
     if([self.reachability currentReachabilityStatus] == NotReachable)
       [self freezeOperations];
+    dispatch_release(originalQueue);
   });
-  dispatch_release(originalQueue);
 }
 
 - (MKNetworkOperation*)imageAtURL:(NSURL *)url onCompletion:(MKNKImageBlock) imageFetchedBlock


### PR DESCRIPTION
Hi again,

I see I messed up with the dispatch_release. It was done too early, as it should be inside the block that uses it. Sorry for that!
