### PR TITLE
notification leak

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -143,7 +143,14 @@ static NSOperationQueue *_sharedNetworkQueue;
   [[NSNotificationCenter defaultCenter] removeObserver:self name:kReachabilityChangedNotification object:nil];
 #if TARGET_OS_IPHONE    
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillTerminateNotification object:nil];
+#elif TARGET_OS_MAC
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationWillHideNotification object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationWillResignActiveNotification object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationWillTerminateNotification object:nil];
 #endif
+
 }
 
 +(void) dealloc {


### PR DESCRIPTION
MKNetworkEngine is registers for notifications but never unregisters

To reproduce:
- Instantiate an MKNetworkEngine
- Enable useCache
- deallocate it (in ARC, set it to null)
- Run and press the home button, so that the application goes to the background. The application will crash
