### PR TITLE
NSJSONSerialization on iOS 4.x fix

### DIFF
--- a/MKNetworkKit/Categories/NSDictionary+RequestEncoding.m
+++ b/MKNetworkKit/Categories/NSDictionary+RequestEncoding.m
@@ -47,22 +47,27 @@
 
 
 -(NSString*) jsonEncodedKeyValueString {
-    
-    if([NSJSONSerialization class]) {
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 50000
+      if(NSClassFromString(@"NSJSONSerialization")) {
         NSError *error = nil;
-        NSData *data = [NSJSONSerialization dataWithJSONObject:self 
-                                                       options:0 // non-pretty printing 
+        NSData *data = [NSJSONSerialization dataWithJSONObject:self
+                                                       options:0 // non-pretty printing
                                                          error:&error];
         if(error)
             DLog(@"JSON Parsing Error: %@", error);
-        
+
         return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     } else {
-        
-        DLog(@"JSON encoder missing, falling back to URL encoding");
-        return [self urlEncodedKeyValueString];
+      DLog(@"JSON encoder missing, falling back to URL encoding");
+      return [self urlEncodedKeyValueString];
     }
+#else
+    DLog(@"JSON encoder missing, falling back to URL encoding");
+    return [self urlEncodedKeyValueString];
+#endif
 }
+
 
 -(NSString*) plistEncodedKeyValueString {
     

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -185,15 +185,23 @@
       }
         break;
       case MKNKPostDataEncodingTypeJSON: {
-        if([NSJSONSerialization class]) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 50000
+        if(NSClassFromString(@"NSJSONSerialization")) {
+        [self.request setValue:
+         [NSString stringWithFormat:@"application/json; charset=%@", charset]
+            forHTTPHeaderField:@"Content-Type"];
+        }
+        else {
           [self.request setValue:
-           [NSString stringWithFormat:@"application/json; charset=%@", charset]
-              forHTTPHeaderField:@"Content-Type"];
-        } else {
-          [self.request setValue:
+             [NSString stringWithFormat:@"application/x-www-form-urlencoded; charset=%@", charset]
+                forHTTPHeaderField:@"Content-Type"];
+
+        }
+#else
+        [self.request setValue:
            [NSString stringWithFormat:@"application/x-www-form-urlencoded; charset=%@", charset]
               forHTTPHeaderField:@"Content-Type"];
-        }
+#endif
       }
         break;
       case MKNKPostDataEncodingTypePlist: {
@@ -1232,18 +1240,23 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
 
 -(id) responseJSON {
   
-  if(NSClassFromString(@"NSJSONSerialization")) {
-    if([self responseData] == nil) return nil;
-    NSError *error = nil;
-    id returnValue = [NSJSONSerialization JSONObjectWithData:[self responseData] options:0 error:&error];    
-    if(error) DLog(@"JSON Parsing Error: %@", error);
-    return returnValue;
-  } else {
-    DLog("You are running on iOS 4. Subclass MKNO and override responseJSON to support custom JSON parsing");
-    return [self responseString];
-  }
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 50000
+    if(NSClassFromString(@"NSJSONSerialization")) {
+      if([self responseData] == nil) return nil;
+      NSError *error = nil;
+      id returnValue = [NSJSONSerialization JSONObjectWithData:[self responseData] options:0 error:&error];
+      if(error) DLog(@"JSON Parsing Error: %@", error);
+      return returnValue;
+    }
+    else {
+      DLog("You are running on iOS 4. Subclass MKNO and override responseJSON to support custom JSON parsing");
+      return [self responseString];
+    }
+#else
+      DLog("You are running on iOS 4. Subclass MKNO and override responseJSON to support custom JSON parsing");
+      return [self responseString];
+#endif
 }
-
 
 #pragma mark -
 #pragma mark Overridable methods


### PR DESCRIPTION
This is fix for #147. In fact even if you properly check class existence application will continue fails if Base SDK is lower than 5.0.
So we should not even compile code that using NSJSONSerialization.

Thanks again for quick answers :)
