### PR TITLE
Fix setPostDataEncoding to work after NSJSONSerialization code cleanup

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -185,7 +185,6 @@
       }
         break;
       case MKNKPostDataEncodingTypeJSON: {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 50000
         if(NSClassFromString(@"NSJSONSerialization")) {
         [self.request setValue:
          [NSString stringWithFormat:@"application/json; charset=%@", charset]
@@ -197,11 +196,6 @@
                 forHTTPHeaderField:@"Content-Type"];
 
         }
-#else
-        [self.request setValue:
-           [NSString stringWithFormat:@"application/x-www-form-urlencoded; charset=%@", charset]
-              forHTTPHeaderField:@"Content-Type"];
-#endif
       }
         break;
       case MKNKPostDataEncodingTypePlist: {


### PR DESCRIPTION
setPostDataEncoding did not work as expected after NSJSONSerilization code cleanup.
You've missed one

```
__IPHONE_OS_VERSION_MAX_ALLOWED
```

which I've removed and now everything works as expected.
