### PR TITLE
Add a target to the iOS Xcode project to build a universal (arm + simulator) static library for inclusion in other projects

### DIFF
--- a/MKNetworkKit-iOS/MKNetworkKit-iOS.xcodeproj/project.pbxproj
+++ b/MKNetworkKit-iOS/MKNetworkKit-iOS.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		929E5A9315AB60F000862231 /* MKNetworkKit-iOS-universal */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 929E5A9615AB60F000862231 /* Build configuration list for PBXAggregateTarget "MKNetworkKit-iOS-universal" */;
+			buildPhases = (
+				929E5A9815AB60FF00862231 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = "MKNetworkKit-iOS-universal";
+			productName = "MKNetworkKit-iOS-universal";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		AB3A308A148F099C00D06246 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB3A3089148F099C00D06246 /* Security.framework */; };
 		AB3A3098148F0A3B00D06246 /* NSDate+RFC1123.h in Headers */ = {isa = PBXBuildFile; fileRef = AB3A3096148F0A3B00D06246 /* NSDate+RFC1123.h */; };
@@ -219,9 +233,27 @@
 			projectRoot = "";
 			targets = (
 				ABB5C25B148B3AE00056D3E9 /* MKNetworkKit-iOS */,
+				929E5A9315AB60F000862231 /* MKNetworkKit-iOS-universal */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		929E5A9815AB60FF00862231 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+				"${BUILT_PRODUCTS_DIR}/../${CONFIGURATION}-iphonesimulator/libMKNetworkKit-iOS.a",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "xcodebuild -configuration \"Release\" -target \"MKNetworkKit-iOS\" -sdk \"iphonesimulator\" ${ACTION} RUN_CLANG_STATIC_ANALYZER=NO BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\"\n\nxcodebuild -configuration \"Release\" -target \"MKNetworkKit-iOS\" -sdk \"iphoneos\" ${ACTION} RUN_CLANG_STATIC_ANALYZER=NO BUILD_DIR=\"${BUILD_DIR}\" BUILD_ROOT=\"${BUILD_ROOT}\"\n\nrm -rf ${BUILT_PRODUCTS_DIR}/../libMKNetworkKit-iOS-universal.a\n\nlipo -create \"${BUILT_PRODUCTS_DIR}/../Release-iphonesimulator/libMKNetworkKit-iOS.a\" \\\n\"${BUILT_PRODUCTS_DIR}/../Release-iphoneos/libMKNetworkKit-iOS.a\" -output \\\n\"${BUILT_PRODUCTS_DIR}/../libMKNetworkKit-iOS-universal.a\"";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		ABB5C258148B3AE00056D3E9 /* Sources */ = {
@@ -242,6 +274,20 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		929E5A9415AB60F000862231 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		929E5A9515AB60F000862231 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		ABB5C267148B3AE00056D3E9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -311,6 +357,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		929E5A9615AB60F000862231 /* Build configuration list for PBXAggregateTarget "MKNetworkKit-iOS-universal" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				929E5A9415AB60F000862231 /* Debug */,
+				929E5A9515AB60F000862231 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		ABB5C256148B3AE00056D3E9 /* Build configuration list for PBXProject "MKNetworkKit-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
Per some comments on the website, it can be useful to build MKNetworkKit as a separate static library. On iOS, this is best done as a universal library that has both arm and x86 code for use on iOS devices and the Simulator. However, Xcode makes this a stupidly difficult task. This patch adds a new target to the project file to automate the process.

The method here is similar to the Facebook iOS build script and that described in http://blog.boreal-kiss.net/2011/03/15/how-to-create-universal-static-libraries-on-xcode-4/. To prevent misunderstandings and confusion, the static library target always builds a release build of the library.
