### PR TITLE
Could you merge this simple fix to your original repo ?

### DIFF
--- a/MKNetworkKit/Reachability/Reachability.m
+++ b/MKNetworkKit/Reachability/Reachability.m
@@ -154,6 +154,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
         CFRelease(self.reachabilityRef);
         self.reachabilityRef = nil;
     }
+    [super dealloc];
 #ifdef DEBUG
     NSLog(@"Reachability: dealloc");
 #endif


### PR DESCRIPTION
Fix compile warning by call super's dealloc on Reachability's dealloc.

The original warning:

```
Method possibly missing a [super dealloc] call
```
