### PR TITLE
Fix issue #132

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -677,8 +677,10 @@
 }
 
 -(void) addData:(NSData*) data forKey:(NSString*) key mimeType:(NSString*) mimeType fileName:(NSString*) fileName {
-  
-  [self.request setHTTPMethod:@"POST"];
+
+  if ([self.request.HTTPMethod isEqualToString:@"GET"]) {
+      [self.request setHTTPMethod:@"POST"];
+  }
   
   NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
                         data, @"data",
@@ -697,7 +699,9 @@
 
 -(void) addFile:(NSString*) filePath forKey:(NSString*) key mimeType:(NSString*) mimeType {
   
-  [self.request setHTTPMethod:@"POST"];
+  if ([self.request.HTTPMethod isEqualToString:@"GET"]) {
+      [self.request setHTTPMethod:@"POST"];
+  }
   
   NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
                         filePath, @"filepath",


### PR DESCRIPTION
When adding data to the request, MKNetworkKit overwrites the HTTP method to POST regardless of its current value. This pull requests sets the method to POST only if it is currently set to GET. I think it is safe to assume that the developer knows what he or she is doing when setting the method to PUT or other.

I spent some time debugging this the first time I've encountered the strange behavior; at first, I set the method to PUT, then added a file to the operation but when it got executed, it was a POST for no apparent reason. The obvious workaround is to set the HTTP method only after adding a file to the operation, but issue #132 is proof that I'm not the only one who encountered this.
