### PR TITLE
A more defensive version of isEqual in MKNetworkOperation

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -289,7 +289,8 @@
 
 -(BOOL) isEqual:(id)object {
   
-  if([self.request.HTTPMethod isEqualToString:@"GET"] || [self.request.HTTPMethod isEqualToString:@"HEAD"]) {
+  if(([self.request.HTTPMethod isEqualToString:@"GET"] || [self.request.HTTPMethod isEqualToString:@"HEAD"]) &&
+     [object isKindOfClass:[self class]]) {
     
     MKNetworkOperation *anotherObject = (MKNetworkOperation*) object;
     return ([[self uniqueIdentifier] isEqualToString:[anotherObject uniqueIdentifier]]);


### PR DESCRIPTION
My colleague encountered an issue with the isEqual method of MKNetworkOperation.

He customized MKNetworkOperation by adding a timeout when executing the operation so it would not hang and would get killed in some time. He used performSelector:withObject:afterDelay: and cancelPreviousPerformRequestsWithTarget:selector:object: to achieve this. It caused the MKNetworkOperation to be compared to other objects, notably UITapRecognizer (not UITapGestureRecognizer, this was some private object). As a result the uniqueIdentifier method was called on the UITapRecognizer instance and that's where our app crashed, for obvious reasons.

This patch prevents similar behavior by comparing if a given object is an instance or inherits from MKNetworkOperation class.
