### PR TITLE
Use copy property attribute for immutable types

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.h
+++ b/MKNetworkKit/MKNetworkEngine.h
@@ -243,7 +243,7 @@
  *  This property is readonly cannot be updated. 
  *  You normally initialize an engine with its hostname using the initWithHostName:customHeaders: method
  */
-@property (readonly, strong, nonatomic) NSString *readonlyHostName;
+@property (readonly, copy, nonatomic) NSString *readonlyHostName;
 
 /*!
  *  @abstract Port Number that should be used by URL creating factory methods
@@ -263,7 +263,7 @@
  *	You can use this method to set a custom path to the API location if your server's API path is different from root (/) 
  *  This property is optional
  */
-@property (strong, nonatomic) NSString* apiPath;
+@property (copy, nonatomic) NSString* apiPath;
 
 /*!
  *  @abstract Handler that you implement to monitor reachability changes

--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -42,9 +42,9 @@
 
 @interface MKNetworkEngine (/*Private Methods*/)
 
-@property (strong, nonatomic) NSString *hostName;
+@property (copy, nonatomic) NSString *hostName;
 @property (strong, nonatomic) Reachability *reachability;
-@property (strong, nonatomic) NSDictionary *customHeaders;
+@property (copy, nonatomic) NSDictionary *customHeaders;
 @property (assign, nonatomic) Class customOperationSubclass;
 
 @property (nonatomic, strong) NSMutableDictionary *memoryCache;

--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -86,7 +86,7 @@ typedef enum {
  *  This property is readonly cannot be updated. 
  *  To create an operation with a specific URL, use the operationWithURLString:params:httpMethod: 
  */
-@property (nonatomic, readonly) NSString *url;
+@property (nonatomic, copy, readonly) NSString *url;
 
 /*!
  *  @abstract The internal request object
@@ -122,7 +122,7 @@ typedef enum {
  *  @seealso
  *   addHeaders:
  */
-@property (nonatomic, strong, readonly) NSDictionary *readonlyPostDictionary;
+@property (nonatomic, copy, readonly) NSDictionary *readonlyPostDictionary;
 
 /*!
  *  @abstract The internal request object's method type
@@ -133,7 +133,7 @@ typedef enum {
  *  This property is readonly cannot be modified. 
  *  To create an operation with a new method type, use the operationWithURLString:params:httpMethod: 
  */
-@property (nonatomic, strong, readonly) NSString *HTTPMethod;
+@property (nonatomic, copy, readonly) NSString *HTTPMethod;
 
 /*!
  *  @abstract The internal response object's status code
@@ -246,7 +246,7 @@ typedef enum {
  *  @discussion
  *	If your request needs to be authenticated using a client certificate, set the certificate path here
  */
-@property (strong, nonatomic) NSString *clientCertificate;
+@property (copy, nonatomic) NSString *clientCertificate;
 
 /*!
  *  @abstract Custom authentication handler

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -41,7 +41,7 @@
 
 @interface MKNetworkOperation (/*Private Methods*/)
 @property (strong, nonatomic) NSURLConnection *connection;
-@property (strong, nonatomic) NSString *uniqueId;
+@property (copy, nonatomic) NSString *uniqueId;
 @property (strong, nonatomic) NSMutableURLRequest *request;
 @property (strong, nonatomic) NSHTTPURLResponse *response;
 
@@ -49,8 +49,8 @@
 @property (strong, nonatomic) NSMutableArray *filesToBePosted;
 @property (strong, nonatomic) NSMutableArray *dataToBePosted;
 
-@property (strong, nonatomic) NSString *username;
-@property (strong, nonatomic) NSString *password;
+@property (copy, nonatomic) NSString *username;
+@property (copy, nonatomic) NSString *password;
 
 @property (nonatomic, strong) NSMutableArray *responseBlocks;
 @property (nonatomic, strong) NSMutableArray *errorBlocks;
@@ -71,7 +71,7 @@
 @property (nonatomic, assign) NSInteger startPosition;
 
 @property (nonatomic, strong) NSMutableArray *downloadStreams;
-@property (nonatomic, strong) NSData *cachedResponse;
+@property (nonatomic, copy) NSData *cachedResponse;
 @property (nonatomic, copy) MKNKResponseBlock cacheHandlingBlock;
 
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
The recommendation is to use copy for classes that are part of a class cluster that have mutable/immutable pairs; such as NSString/NSMutableString NSArray/NSMutableArray NSDictionary/NSMutableDictionary NSSet/NSMutableSet.
The reason for this is that it is possible to have a property that is declared as an immutable type (such as NSString) yet pass it a mutable type (such as NSMutableString). In which case it is possible to change the property from outside the class as Taskinoor describes.
Using copy is recommended, because it behaves sensibly with class clusters. sending copy to a mutable class returns an immutable copy of the object (i.e. sending a copy message to an NSMutableString returns an NSString). But, sending copy to an immutable counterpart is equivalent to sending it a retain message.

Not my text! From StackOverflow:
http://stackoverflow.com/questions/4995254/nsmutablestring-as-retain-copy/5002646#5002646
