### PR TITLE
Replaced `NSDateFormatter` with faster `strptime_l` and `strftime_l` and fixed OS X compile errors.

### DIFF
--- a/MKNetworkKit-OSX/MKNetworkKit-OSX.xcodeproj/project.pbxproj
+++ b/MKNetworkKit-OSX/MKNetworkKit-OSX.xcodeproj/project.pbxproj
@@ -24,8 +24,8 @@
 		ABB5C2A6148B3B160056D3E9 /* MKNetworkOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = ABB5C297148B3B160056D3E9 /* MKNetworkOperation.m */; };
 		ABB5C2A7148B3B160056D3E9 /* Reachability.h in Headers */ = {isa = PBXBuildFile; fileRef = ABB5C299148B3B160056D3E9 /* Reachability.h */; };
 		ABB5C2A8148B3B160056D3E9 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = ABB5C29A148B3B160056D3E9 /* Reachability.m */; };
-		ABDC974A1498A8B60034CEBE /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = ABDC97481498A8B60034CEBE /* NSData+Base64.h */; };
-		ABDC974B1498A8B60034CEBE /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = ABDC97491498A8B60034CEBE /* NSData+Base64.m */; };
+		ABDC974A1498A8B60034CEBE /* NSData+MKBase64.h in Headers */ = {isa = PBXBuildFile; fileRef = ABDC97481498A8B60034CEBE /* NSData+MKBase64.h */; };
+		ABDC974B1498A8B60034CEBE /* NSData+MKBase64.m in Sources */ = {isa = PBXBuildFile; fileRef = ABDC97491498A8B60034CEBE /* NSData+MKBase64.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,8 +51,8 @@
 		ABB5C297148B3B160056D3E9 /* MKNetworkOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MKNetworkOperation.m; path = ../../MKNetworkKit/MKNetworkOperation.m; sourceTree = "<group>"; };
 		ABB5C299148B3B160056D3E9 /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = "<group>"; };
 		ABB5C29A148B3B160056D3E9 /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = "<group>"; };
-		ABDC97481498A8B60034CEBE /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Base64.h"; sourceTree = "<group>"; };
-		ABDC97491498A8B60034CEBE /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Base64.m"; sourceTree = "<group>"; };
+		ABDC97481498A8B60034CEBE /* NSData+MKBase64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+MKBase64.h"; sourceTree = "<group>"; };
+		ABDC97491498A8B60034CEBE /* NSData+MKBase64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+MKBase64.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,8 +131,8 @@
 		ABB5C28C148B3B160056D3E9 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
-				ABDC97481498A8B60034CEBE /* NSData+Base64.h */,
-				ABDC97491498A8B60034CEBE /* NSData+Base64.m */,
+				ABDC97481498A8B60034CEBE /* NSData+MKBase64.h */,
+				ABDC97491498A8B60034CEBE /* NSData+MKBase64.m */,
 				AB3A309A148F0A4400D06246 /* NSDate+RFC1123.h */,
 				AB3A309B148F0A4400D06246 /* NSDate+RFC1123.m */,
 				ABB5C28D148B3B160056D3E9 /* NSDictionary+RequestEncoding.h */,
@@ -171,7 +171,7 @@
 				ABB5C2A7148B3B160056D3E9 /* Reachability.h in Headers */,
 				AB8AF0CA148B445200ECE140 /* NSAlert+MKNetworkKitAdditions.h in Headers */,
 				AB3A309C148F0A4400D06246 /* NSDate+RFC1123.h in Headers */,
-				ABDC974A1498A8B60034CEBE /* NSData+Base64.h in Headers */,
+				ABDC974A1498A8B60034CEBE /* NSData+MKBase64.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,7 +233,7 @@
 				ABB5C2A8148B3B160056D3E9 /* Reachability.m in Sources */,
 				AB8AF0CB148B445200ECE140 /* NSAlert+MKNetworkKitAdditions.m in Sources */,
 				AB3A309D148F0A4400D06246 /* NSDate+RFC1123.m in Sources */,
-				ABDC974B1498A8B60034CEBE /* NSData+Base64.m in Sources */,
+				ABDC974B1498A8B60034CEBE /* NSData+MKBase64.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MKNetworkKit/Categories/NSDate+RFC1123.m
+++ b/MKNetworkKit/Categories/NSDate+RFC1123.m
@@ -2,12 +2,14 @@
 //  NSDate+RFC1123.m
 //  MKNetworkKit
 //
-//  Created by Marcus Rohrmoser
+//  Originally created by Marcus Rohrmoser
 //  http://blog.mro.name/2009/08/nsdateformatter-http-header/
 //
 //  No obvious license attached
 
 #import "NSDate+RFC1123.h"
+#import <time.h>
+#import <xlocale.h>
 
 @implementation NSDate (RFC1123)
 
@@ -16,64 +18,58 @@
     if(value_ == nil)
         return nil;    
     
-    __strong static NSDateFormatter *rfc1123 = nil;
-    if (!rfc1123) {
-        static dispatch_once_t oncePredicate;
-        dispatch_once(&oncePredicate, ^{
-            rfc1123 = [[NSDateFormatter alloc] init];
-            rfc1123.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
-            rfc1123.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
-            rfc1123.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss z";
-        });
-    }
-    NSDate *ret = [rfc1123 dateFromString:value_];
-    if(ret != nil)
-        return ret;
+    const char *str = [value_ UTF8String];
+    const char *fmt;
+    NSDate *retDate;
+    char *ret;
     
-    static NSDateFormatter *rfc850 = nil;
-    if(!rfc850)
-    {
-        static dispatch_once_t oncePredicate;
-        dispatch_once(&oncePredicate, ^{
-            rfc850 = [[NSDateFormatter alloc] init];
-            rfc850.locale = rfc1123.locale;
-            rfc850.timeZone = rfc1123.timeZone;
-            rfc850.dateFormat = @"EEEE',' dd'-'MMM'-'yy HH':'mm':'ss z";
-        });
+    fmt = "%a, %d %b %Y %H:%M:%S %Z";
+    struct tm rfc1123timeinfo;
+    memset(&rfc1123timeinfo, 0, sizeof(rfc1123timeinfo));
+    ret = strptime_l(str, fmt, &rfc1123timeinfo, NULL);
+    if (ret) {
+        time_t rfc1123time = mktime(&rfc1123timeinfo);
+        retDate = [NSDate dateWithTimeIntervalSince1970:rfc1123time];
+        if (retDate != nil)
+            return retDate;
     }
-    ret = [rfc850 dateFromString:value_];
-    if(ret != nil)
-        return ret;
     
-    static NSDateFormatter *asctime = nil;
-    if(!asctime)
-    {
-        static dispatch_once_t oncePredicate;
-        dispatch_once(&oncePredicate, ^{
-            
-            asctime = [[NSDateFormatter alloc] init];
-            asctime.locale = rfc1123.locale;
-            asctime.timeZone = rfc1123.timeZone;
-            asctime.dateFormat = @"EEE MMM d HH':'mm':'ss yyyy";
-        });
+    
+    fmt = "%A, %d-%b-%y %H:%M:%S %Z";
+    struct tm rfc850timeinfo;
+    memset(&rfc850timeinfo, 0, sizeof(rfc850timeinfo));
+    ret = strptime_l(str, fmt, &rfc850timeinfo, NULL);
+    if (ret) {
+        time_t rfc850time = mktime(&rfc850timeinfo);
+        retDate = [NSDate dateWithTimeIntervalSince1970:rfc850time];
+        if (retDate != nil)
+            return retDate;
     }
-    return [asctime dateFromString:value_];
+    
+    fmt = "%a %b %e %H:%M:%S %Y";
+    struct tm asctimeinfo;
+    memset(&asctimeinfo, 0, sizeof(asctimeinfo));
+    ret = strptime_l(str, fmt, &asctimeinfo, NULL);
+    if (ret) {
+        time_t asctime = mktime(&asctimeinfo);
+        return [NSDate dateWithTimeIntervalSince1970:asctime];
+    }
+    
+    return nil;
 }
 
 -(NSString*)rfc1123String
 {
-    static NSDateFormatter *df = nil;
-    if(!df)
-    {
-        static dispatch_once_t oncePredicate;
-        dispatch_once(&oncePredicate, ^{
-            df = [[NSDateFormatter alloc] init];
-            df.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
-            df.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
-            df.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'";
-        });
+    time_t date = (time_t)[self timeIntervalSince1970];
+    struct tm timeinfo;
+    gmtime_r(&date, &timeinfo);
+    char buffer[32];
+    size_t ret = strftime_l(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S GMT", &timeinfo, NULL);
+    if (ret) {
+        return @(buffer);
+    } else {
+        return nil;
     }
-    return [df stringFromDate:self];
 }
 
 @end

--- a/MKNetworkKit/MKNetworkEngine.h
+++ b/MKNetworkKit/MKNetworkEngine.h
@@ -190,6 +190,7 @@
  */
 -(void) prepareHeaders:(MKNetworkOperation*) operation;
 
+#if TARGET_OS_IPHONE
 /*!
  *  @abstract Handy helper method for fetching images asynchronously in the background
  *
@@ -201,6 +202,7 @@
  *  imageAtUrl:onCompletion:
  */
 - (MKNetworkOperation*)imageAtURL:(NSURL *)url size:(CGSize) size onCompletion:(MKNKImageBlock) imageFetchedBlock;
+#endif
 
 /*!
  *  @abstract Handy helper method for fetching images

--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -452,6 +452,7 @@ static NSOperationQueue *_sharedNetworkQueue;
   });
 }
 
+#if TARGET_OS_IPHONE
 - (MKNetworkOperation*)imageAtURL:(NSURL *)url size:(CGSize) size onCompletion:(MKNKImageBlock) imageFetchedBlock {
   
 #ifdef DEBUG
@@ -488,6 +489,7 @@ static NSOperationQueue *_sharedNetworkQueue;
   
   return op;
 }
+#endif
 
 - (MKNetworkOperation*)imageAtURL:(NSURL *)url onCompletion:(MKNKImageBlock) imageFetchedBlock
 {


### PR DESCRIPTION
A chunk of my app run time is spent in `dateFromRFC1123`. I replaced `NSDateFormatte`r with `strptime_l` and `strftime_l` which are faster. I also fixed a couple of OS X compile errors too,
