### PR TITLE
Position of #endif prevents compiling for OSX

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -521,12 +521,13 @@ static NSOperationQueue *_sharedNetworkQueue;
   return [self imageAtURL:url size:size completionHandler:imageFetchedBlock errorHandler:^(MKNetworkOperation* op, NSError* error){}];
 }
 
-#endif
-
 - (MKNetworkOperation*)imageAtURL:(NSURL *)url onCompletion:(MKNKImageBlock) imageFetchedBlock
 {
   return [self imageAtURL:url completionHandler:imageFetchedBlock errorHandler:^(MKNetworkOperation* op, NSError* error){}];
 }
+
+#endif
+
 
 #pragma mark -
 #pragma mark Cache related


### PR DESCRIPTION
Putting the message `- (MKNetworkOperation*)imageAtURL:(NSURL *)url onCompletion:(MKNKImageBlock) imageFetchedBlock`inside the #ifdef block assures compiling for OSX.

Btw: 
Your podspec file misses following:
```s.prefix_header_contents = '#ifdef **OBJC**
# import "MKNetworkKit.h"
# endif'```
