### PR TITLE
Upload from a stream

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -43,6 +43,8 @@ typedef void (^MKNKImageBlock) (NSImage* fetchedImage, NSURL* url, BOOL isInCach
 typedef void (^MKNKResponseErrorBlock)(MKNetworkOperation* completedOperation, NSError* error);
 typedef void (^MKNKErrorBlock)(NSError* error);
 
+typedef NSInputStream *(^MKNKUploadStreamConstructorBlock)(MKNetworkOperation *operation, NSURLConnection *connection);
+
 typedef void (^MKNKAuthBlock)(NSURLAuthenticationChallenge* challenge);
 
 typedef NSString* (^MKNKEncodingBlock) (NSDictionary* postDataDict);
@@ -460,6 +462,17 @@ typedef enum {
  *
  */
 -(void) setUploadStream:(NSInputStream*) inputStream;
+
+/*!
+ *  @abstract Sets a constructor for creating a stream for upload
+ *
+ *  @discussion
+ *	This method can be used to upload a resource for a post body directly from a stream.
+ *  We have to use a constructor, not a stream directly, because in some cases we need
+ *  to recreate a stream. See https://devforums.apple.com/message/344093 for details.
+ *
+ */
+-(void) setUploadStreamConstructor:(MKNKUploadStreamConstructorBlock) uploadStreamConstructor
 
 /*!
  *  @abstract Downloads a resource directly to a file or any output stream


### PR DESCRIPTION
When I've tried to use `setUploadStream:` I got error "request body stream exhausted". After some researching I've found some topics on apple's dev forums where was said that method `-connection: needNewBodyStream:` must be implemented. 
Here are some related dissuasions with answers from apple's engineers: 
https://devforums.apple.com/message/255325#255325
https://devforums.apple.com/message/237388

Also I found that we have to set "Expect: 100-Continue" header. Here is also related answer from apple's engineer: https://devforums.apple.com/message/344093#344093

I'm not 100% sure about this code and need somebody else for comments and advices. I don't use anymore upload via stream in my project( But will be glad to help to do it possible with MKNetworkKit.

Also searching for `needNewBodyStream` during all time on apple's dev forum may give you some other interesting discussions: https://devforums.apple.com/search.jspa?q=needNewBodyStream&resultTypes=MESSAGE&peopleEnabled=true&communityID=&dateRange=all&username=
