### PR TITLE
Check block != nil before invoking them in imageAtURL:completionHandler:errorHandler:

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -479,13 +479,14 @@ static NSOperationQueue *_sharedNetworkQueue;
   
   [op addCompletionHandler:^(MKNetworkOperation *completedOperation) {
     
-    imageFetchedBlock([completedOperation responseImage],
-                      url,
-                      [completedOperation isCachedResponse]);
+    if (imageFetchedBlock)
+        imageFetchedBlock([completedOperation responseImage],
+                          url,
+                          [completedOperation isCachedResponse]);
     
   } errorHandler:^(MKNetworkOperation *completedOperation, NSError *error) {
-    
-    errorBlock(completedOperation, error);
+      if (errorBlock)
+          errorBlock(completedOperation, error);
   }];
   
   [self enqueueOperation:op];


### PR DESCRIPTION
it should not crash if nil is passed as a handler.
