### PR TITLE
fix compiler warning macro redefined when using DLog defined outside of MKNetworkKit

### DIFF
--- a/MKNetworkKit/MKNetworkKit.h
+++ b/MKNetworkKit/MKNetworkKit.h
@@ -44,15 +44,25 @@
 #endif
 
 #ifdef DEBUG
+#ifndef DLog
 #   define DLog(fmt, ...) {NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);}
+#endif
+#ifndef ELog
 #   define ELog(err) {if(err) DLog(@"%@", err)}
+#endif
 #else
+#ifndef DLog
 #   define DLog(...)
+#endif
+#ifndef ELog
 #   define ELog(err)
+#endif
 #endif
 
 // ALog always displays output regardless of the DEBUG setting
+#ifndef ALog
 #define ALog(fmt, ...) {NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);};
+#endif
 
 #import "Categories/NSString+MKNetworkKitAdditions.h"
 #import "Categories/NSDictionary+RequestEncoding.h"


### PR DESCRIPTION
...MKNetworkKit
