### PR TITLE
Bug fix in imageAtURL:

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -536,15 +536,15 @@ static NSOperationQueue *_sharedNetworkQueue;
   [op addCompletionHandler:^(MKNetworkOperation *completedOperation) {
     [completedOperation decompressedResponseImageOfSize:size
                                       completionHandler:^(UIImage *decompressedImage) {
-                                        
-                                        imageFetchedBlock(decompressedImage,
-                                                          url,
-                                                          [completedOperation isCachedResponse]);
+                                          if (imageFetchedBlock)
+                                              imageFetchedBlock(decompressedImage,
+                                                                url,
+                                                                [completedOperation isCachedResponse]);
                                       }];
   } errorHandler:^(MKNetworkOperation *completedOperation, NSError *error) {
-    
-    errorBlock(completedOperation, error);
-    DLog(@"%@", error);
+      if (errorBlock)
+          errorBlock(completedOperation, error);
+      DLog(@"%@", error);
   }];
   
   [self enqueueOperation:op];


### PR DESCRIPTION
hey

just a small commit to fix a crash in the imageAtURL: method when it is passed a NULL error handler.

ta//
