### PR TITLE
Allow binary data uploads

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -395,6 +395,16 @@ typedef enum {
 -(void) addFile:(NSString*) filePath forKey:(NSString*) key mimeType:(NSString*) mimeType;
 
 /*!
+ *  @abstract Attach raw data to a request for uploads without a mime
+ * 
+ *  @discussion
+ *  This method lets you attach binary data to a request and have only that data uploaded.
+ *  This method has a side effect. It chages the HTTPMethod to "POST" regardless of what it was before.
+ */
+
+-(void)addRawData:(NSData *)data;
+
+/*!
  *  @abstract Attaches a resource to the request from a NSData pointer
  *  
  *  @discussion

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -64,6 +64,7 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
 @property (nonatomic, assign) MKNetworkOperationState state;
 @property (nonatomic, assign) BOOL isCancelled;
 
+@property (strong, nonatomic) NSMutableData *mutableRawData;
 @property (strong, nonatomic) NSMutableData *mutableData;
 @property (assign, nonatomic) NSUInteger downloadedDataSize;
 
@@ -678,6 +679,16 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
   return displayString;
 }
 
+-(void)addRawData:(NSData *)data {
+    if ([self.request.HTTPMethod isEqualToString:@"GET"]) {
+      [self.request setHTTPMethod:@"POST"];
+    }
+    if (!self.mutableRawData) {
+        self.mutableRawData = [NSMutableData data];
+    }
+    [self.mutableRawData appendData:data];
+}
+
 
 -(void) addData:(NSData*) data forKey:(NSString*) key {
   
@@ -717,6 +728,9 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
 }
 
 -(NSData*) bodyData {
+    if (self.mutableRawData) {
+        return self.mutableRawData;
+    }
   
   if([self.filesToBePosted count] == 0 && [self.dataToBePosted count] == 0) {
     


### PR DESCRIPTION
Allow simply binary data uploads by calling the 'addRawData' method on MKNetworkoperation. This sets httpMethod to POST. Caution though, raw data overrides any mime data added (as it should).
