### PR TITLE
Adding a property to allow you to turn off call failure logging, preserving existing behavior.

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -242,6 +242,15 @@ typedef enum {
 @property (nonatomic, assign) BOOL shouldContinueWithInvalidCertificate;
 
 /*!
+ *  @abstract Boolean variable that states whether the operation should log call failures
+ *  @property failWithoutLogging
+ *
+ *  @discussion
+ *	If you set this property to YES, the operation will not log failed calls from operationFailedWithError.
+ */
+@property (nonatomic, assign) BOOL failWithoutLogging;
+
+/*!
  *  @abstract Cache headers of the response
  *  @property cacheHeaders
  *  

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -1451,7 +1451,7 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
 -(void) operationFailedWithError:(NSError*) error {
   
   self.error = error;
-  DLog(@"%@, [%@]", self, [self.error localizedDescription]);
+  if (!self.failWithoutLogging) DLog(@"%@, [%@]", self, [self.error localizedDescription]);
   for(MKNKErrorBlock errorBlock in self.errorBlocks)
     errorBlock(error);
   
@@ -1459,7 +1459,7 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
     errorBlock(self, error);
   
 #if TARGET_OS_IPHONE
-  DLog(@"State: %d", [[UIApplication sharedApplication] applicationState]);
+  if (!self.failWithoutLogging) DLog(@"State: %d", [[UIApplication sharedApplication] applicationState]);
   if([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground)
     [self showLocalNotification];
 #endif


### PR DESCRIPTION
We have some noisy calls we'd like to shut up.
