### PR TITLE
Fix a bug if Image decompression failed, no callback for the operation

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -1353,6 +1353,9 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
     CGColorSpaceRelease(colorSpace);
     if (!context) {
       DLog(@"Image decompression failed. Context is nil. Could happen if your image view size is CGSizeZero");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            imageDecompressionHandler(nil);
+        });
       return;
     }
     


### PR DESCRIPTION
Like I had a waiting view show up before start image downloading, and hide the waiting view when image finished downloading.

If the decompression failed, the caller can not get callback
