### PR TITLE
Expose some elements of MKNetworkOperation

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -78,6 +78,10 @@ typedef enum {
   MKNKPostDataEncodingType _postDataEncoding;
 }
 
+@property (strong, nonatomic) NSURLConnection *connection;
+@property (strong, nonatomic) NSMutableURLRequest *request;
+@property (strong, nonatomic) NSHTTPURLResponse *response;
+
 /*!
  *  @abstract Request URL Property
  *  @property url
@@ -643,6 +647,12 @@ typedef enum {
  *
  */
 -(void) operationFailedWithError:(NSError*) error;
+
+-(NSURLRequest *) connection: (NSURLConnection *)inConnection
+             willSendRequest: (NSURLRequest *)inRequest
+            redirectResponse: (NSURLResponse *)inRedirectResponse;
+
+-(void) connectionDidFinishLoading:(NSURLConnection *)connection;
 
 // internal methods called by MKNetworkEngine only.
 // Don't touch

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -45,10 +45,7 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
                                  CFStringRef keyPassword);
 
 @interface MKNetworkOperation (/*Private Methods*/)
-@property (strong, nonatomic) NSURLConnection *connection;
 @property (copy, nonatomic) NSString *uniqueId;
-@property (strong, nonatomic) NSMutableURLRequest *request;
-@property (strong, nonatomic) NSHTTPURLResponse *response;
 
 @property (strong, nonatomic) NSMutableDictionary *fieldsToBePosted;
 @property (strong, nonatomic) NSMutableArray *filesToBePosted;


### PR DESCRIPTION
Expose some elements of MKNetworkOperation so that they can be referenced from subclasses.

This adds connection:willSendRequest:redirectResponse: and
connectionDidFinishLoading: to its public interface, and moves
connection, request, and response from the private to the public.

This allows subclasses of MKNetworkOperation to override
those methods while still calling the base class.  It also allows
connection, request, and response to be referenced from those overrides.
