### PR TITLE
Make it possible to prevent the addition of the Accept-Language header.

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.h
+++ b/MKNetworkKit/MKNetworkEngine.h
@@ -389,4 +389,13 @@
  */
 -(BOOL) isReachable;
 
+/*!
+ *  @abstract Boolean variable that states whether the request should automatically include an Accept-Language header.
+ *  @property shouldSendAcceptLanguageHeader
+ *
+ *  @discussion
+ *	The default value is YES. MKNetworkKit will generate an Accept-Language header using [NSLocale preferredLanguages] + "en-US".
+ */
+@property (nonatomic, assign) BOOL shouldSendAcceptLanguageHeader;
+
 @end

--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -131,6 +131,7 @@ static NSOperationQueue *_sharedNetworkQueue;
     }
     
     self.customOperationSubclass = [MKNetworkOperation class];
+    self.shouldSendAcceptLanguageHeader = YES;
   }
   
   return self;
@@ -372,6 +373,7 @@ static NSOperationQueue *_sharedNetworkQueue;
                                    httpMethod:(NSString*)method {
   
   MKNetworkOperation *operation = [[self.customOperationSubclass alloc] initWithURLString:urlString params:body httpMethod:method];
+  operation.shouldSendAcceptLanguageHeader = self.shouldSendAcceptLanguageHeader;
   
   [self prepareHeaders:operation];
   return operation;

--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -242,6 +242,16 @@ typedef enum {
 @property (nonatomic, assign) BOOL shouldContinueWithInvalidCertificate;
 
 /*!
+ *  @abstract Boolean variable that states whether the request should automatically include an Accept-Language header.
+ *  @property shouldSendAcceptLanguageHeader
+ *
+ *  @discussion
+ *	If set to YES, then MKNetworkKit will generate an Accept-Language header using [NSLocale preferredLanguages] + "en-us".
+ *  This is set by MKNetworkEngine when it creates the MKNetworkOperation instance, so it gets its default from there.
+ */
+@property (nonatomic, assign) BOOL shouldSendAcceptLanguageHeader;
+
+/*!
  *  @abstract Cache headers of the response
  *  @property cacheHeaders
  *  


### PR DESCRIPTION
This adds shouldSendAcceptLanguageHeader to MKNetworkEngine and
MKNetworkOperation (the value on Operation is set by Engine when the
Operation is created).

This defaults to YES, preserving the existing behavior.

If set to NO, then no Accepts-Language header is added to the request.
For API calls that are not language-dependent, this can save a significant
fraction of the request size, since the NSLocale preferredLanguages list
can be long.

This changeset moves the code to set the Accepts-Language header out of
MKNetworkOperation initWithURLString and into
connection:willSendRequest:redirectResponse:.  This is necessary because
NSURLConnection sets a default Accepts-Language: en-us header if you
try to omit it.  You have to explicitly delete it again before the
request is sent.
