### PR TITLE
Implement MKNetworkOperation copyForRetry.

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -644,6 +644,14 @@ typedef enum {
  */
 -(void) operationFailedWithError:(NSError*) error;
 
+/*!
+ *  @abstract Copy this MKNetworkOperation, with the intention of retrying the call.
+ *
+ *  @discussion This means that the request parameters and callbacks are all preserved, but anything related
+ *  to an ongoing request is discarded, so that a new request with the same configuration can be made.
+ */
+-(instancetype) copyForRetry;
+
 // internal methods called by MKNetworkEngine only.
 // Don't touch
 -(BOOL) isCacheable;

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -442,6 +442,43 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
   return theCopy;
 }
 
+- (instancetype)copyForRetry
+{
+    MKNetworkOperation *theCopy = [[[self class] alloc] init];
+    
+    [theCopy setConnection:nil];
+    [theCopy setResponse:nil];
+    [theCopy setState:MKNetworkOperationStateReady];
+    [theCopy setIsCancelled:NO];
+    [theCopy setDownloadedDataSize:0];
+    [theCopy setStartPosition:0];
+
+    theCopy.postDataEncoding = _postDataEncoding;
+    [theCopy setStringEncoding:self.stringEncoding];
+    [theCopy setUniqueId:[self.uniqueId copy]];
+    [theCopy setRequest:[self.request copy]];
+    [theCopy setFieldsToBePosted:[self.fieldsToBePosted copy]];
+    [theCopy setFilesToBePosted:[self.filesToBePosted copy]];
+    [theCopy setDataToBePosted:[self.dataToBePosted copy]];
+    [theCopy setUsername:[self.username copy]];
+    [theCopy setPassword:[self.password copy]];
+    [theCopy setClientCertificate:[self.clientCertificate copy]];
+    [theCopy setClientCertificatePassword:[self.clientCertificatePassword copy]];
+    [theCopy setResponseBlocks:[self.responseBlocks copy]];
+    [theCopy setErrorBlocks:[self.errorBlocks copy]];
+    [theCopy setErrorBlocksType2:[self.errorBlocksType2 copy]];
+    [theCopy setMutableData:[self.mutableData copy]];
+    [theCopy setNotModifiedHandlers:[self.notModifiedHandlers copy]];
+    [theCopy setUploadProgressChangedHandlers:[self.uploadProgressChangedHandlers copy]];
+    [theCopy setDownloadProgressChangedHandlers:[self.downloadProgressChangedHandlers copy]];
+    [theCopy setDownloadStreams:[self.downloadStreams copy]];
+    [theCopy setCachedResponse:[self.cachedResponse copy]];
+    [theCopy setCacheHandlingBlock:self.cacheHandlingBlock];
+    [theCopy setCredentialPersistence:self.credentialPersistence];
+    
+    return theCopy;
+}
+
 -(void) dealloc {
   
   [_connection cancel];


### PR DESCRIPTION
This copies the MKNetworkOperation, with the intention of retrying the call.
This means that the request parameters and callbacks are all preserved, but
anything related to an ongoing request is discarded, so that a new request
with the same configuration can be made.
