### PR TITLE
Add a new constructor that takes a port.

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.h
+++ b/MKNetworkKit/MKNetworkEngine.h
@@ -80,6 +80,21 @@
 - (id) initWithHostName:(NSString*) hostName apiPath:(NSString*) apiPath customHeaderFields:(NSDictionary*) headers;
 
 /*!
+ *  @abstract Initializes your network engine with a hostname, port, path, and headers.
+ *
+ *  @discussion
+ *	Creates an engine for a given host name
+ *  The hostname parameter is optional
+ *  The port parameter can be 0, which means to use the appropriate default port (80 or 443 for HTTP or HTTPS respectively).
+ *  The apiPath paramter is optional
+ *  The apiPath is prefixed to every call to operationWithPath: You can use this method if your server's API location is not at the root (/)
+ *  The hostname, if not null, initializes a Reachability notifier.
+ *  Network reachability notifications are automatically taken care of by MKNetworkEngine
+ *
+ */
+- (id) initWithHostName:(NSString*) hostName portNumber:(int)portNumber apiPath:(NSString*) apiPath customHeaderFields:(NSDictionary*) headers;
+
+/*!
  *  @abstract Creates a simple GET Operation with a request URL
  *  
  *  @discussion

--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -97,8 +97,13 @@ static NSOperationQueue *_sharedNetworkQueue;
 
 - (id) initWithHostName:(NSString*) hostName apiPath:(NSString*) apiPath customHeaderFields:(NSDictionary*) headers {
   
+  return [self initWithHostName:hostName portNumber:0 apiPath:apiPath customHeaderFields:headers];
+}
+
+- (id) initWithHostName:(NSString*) hostName portNumber:(int)portNumber apiPath:(NSString*) apiPath customHeaderFields:(NSDictionary*) headers {
   if((self = [super init])) {
     
+    self.portNumber = portNumber;
     self.apiPath = apiPath;
     self.backgroundCacheQueue = dispatch_queue_create("com.mknetworkkit.cachequeue", DISPATCH_QUEUE_SERIAL);
     self.operationQueue = dispatch_queue_create("com.mknetworkkit.operationqueue", DISPATCH_QUEUE_SERIAL);


### PR DESCRIPTION
This adds initWithHostName:portNumber:apiPath:customHeaderFields: and
has initWithHostName:apiPath:customHeaderFields: call it in turn.

This allows callers to specify host and port in one step.
