### PR TITLE
Implement cancelOperationsMatchingBlock.

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.h
+++ b/MKNetworkKit/MKNetworkEngine.h
@@ -269,6 +269,15 @@
 +(void) cancelOperationsContainingURLString:(NSString*) string;
 
 /*!
+ *  @abstract Cancels operations matching the given block.
+ *
+ *  @discussion
+ *	Cancels all operations in the shared queue for which the given block returns YES.
+ *
+ */
++(void) cancelOperationsMatchingBlock:(BOOL (^)(MKNetworkOperation*))block;
+
+/*!
  *  @abstract Cancels all operations created by this engine
  *
  *  @discussion

--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -239,15 +239,20 @@ static NSOperationQueue *_sharedNetworkQueue;
 
 +(void) cancelOperationsContainingURLString:(NSString*) string {
   
-  NSArray *runningOperations = _sharedNetworkQueue.operations;
-  [runningOperations enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-    
-    MKNetworkOperation *thisOperation = obj;
-    if([[thisOperation.readonlyRequest.URL absoluteString] rangeOfString:string].location != NSNotFound) {
-    
-      [thisOperation cancel];
-    }
+  [self cancelOperationsMatchingBlock:^BOOL (MKNetworkOperation* op) {
+    return [[op.readonlyRequest.URL absoluteString] rangeOfString:string].location != NSNotFound;
   }];
+}
+
++(void) cancelOperationsMatchingBlock:(BOOL (^)(MKNetworkOperation* op))block {
+    
+    NSArray *runningOperations = _sharedNetworkQueue.operations;
+    [runningOperations enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        
+        MKNetworkOperation *thisOperation = obj;
+        if (block(thisOperation))
+            [thisOperation cancel];
+    }];
 }
 
 -(void) cancelAllOperations {


### PR DESCRIPTION
This cancels all operations in the shared queue for which the given block
returns YES.

cancelOperationsContainingURLString is now implemented in terms of
cancelOperationsMatchingBlock.
