### PR TITLE
Refactor to allow easier overriding.

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.h
+++ b/MKNetworkKit/MKNetworkOperation.h
@@ -656,4 +656,24 @@ typedef enum {
 - (id)initWithURLString:(NSString *)aURLString
                  params:(NSDictionary *)params
              httpMethod:(NSString *)method;
+
+
+// These methods are available for subclasses to override the way that
+// this class handles connection:didFailWithError: and connectionDidFinishLoading:.
+// You are not likely to need to call them from outside this class.
+
+-(void) setResponseData:(NSData*)data;
+-(void) setResponseJSON:(id)obj error:(NSError**)error;
+
+/*!
+ @abstract Set the response status code and headers.
+ @discussion This is useful if a subclass wants to manipulate the response, e.g. for mocking or fault injection.
+ Note that NSHTTPURLResponse is immutable, so this actually replaces self.response with a new instance.
+ */
+-(void) setResponseStatusCode:(NSInteger)statusCode andHeaderFields:(NSDictionary*)headerFields;
+
+-(void)updateStateForFinishedConnection:(NSURLConnection *)connection clearData:(BOOL)clearData;
+-(void)sendNotificationsForFinishedConnection:(NSURLConnection *)connection;
+
+
 @end

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -939,14 +939,8 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
   
-  self.state = MKNetworkOperationStateFinished;
-  self.mutableData = nil;
-  self.downloadedDataSize = 0;
-  for(NSOutputStream *stream in self.downloadStreams)
-    [stream close];
-  
+  [self updateStateForFinishedConnection:connection clearData:YES];
   [self operationFailedWithError:error];
-  [self endBackgroundTask];
 }
 
 // https://developer.apple.com/library/mac/#documentation/security/conceptual/CertKeyTrustProgGuide/iPhone_Tasks/iPhone_Tasks.html
@@ -1251,11 +1245,25 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
   if([self isCancelled])
     return;
   
+  [self updateStateForFinishedConnection:connection clearData:NO];
+  [self sendNotificationsForFinishedConnection:connection];
+}
+
+-(void)updateStateForFinishedConnection:(NSURLConnection *)connection clearData:(BOOL)clearData {
   self.state = MKNetworkOperationStateFinished;
   
   for(NSOutputStream *stream in self.downloadStreams)
     [stream close];
   
+  if (clearData) {
+    self.mutableData = nil;
+    self.downloadedDataSize = 0;
+  }
+  
+  [self endBackgroundTask];
+}
+
+-(void)sendNotificationsForFinishedConnection:(NSURLConnection *)connection {
   if (self.response.statusCode >= 200 && self.response.statusCode < 300 && ![self isCancelled]) {
     
     self.cachedResponse = nil; // remove cached data
@@ -1289,8 +1297,6 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
                                                        code:self.response.statusCode
                                                    userInfo:self.response.allHeaderFields]];
   }
-  [self endBackgroundTask];
-  
 }
 
 #pragma mark -
@@ -1315,6 +1321,19 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
   
   return [[NSString alloc] initWithData:[self responseData] encoding:encoding];
 }
+
+-(void) setResponseData:(NSData*)data {
+  self.mutableData = [data mutableCopy];
+}
+
+-(void)setResponseJSON:(id)obj error:(NSError**)error {
+  [self setResponseData:[NSJSONSerialization dataWithJSONObject:obj options:0 error:error]];
+}
+
+-(void)setResponseStatusCode:(NSInteger)statusCode andHeaderFields:(NSDictionary*)headerFields {
+    self.response = [[NSHTTPURLResponse alloc] initWithURL:self.response.URL statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:headerFields];
+}
+
 
 #if TARGET_OS_IPHONE
 -(UIImage*) responseImage {


### PR DESCRIPTION
Refactor the handling of connection:didFailWithError: and
connectionDidFinishLoading: so that it is easier for subclasses of
MKNetworkOperation to override aspects of that handling.

This takes the piece for tidying up internal state into
updateStateForFinishedConnection (cleaning up some duplicated code on the
way) and puts the actual response interpretation into
sendNotificationsForFinishedConnection.

This also adds setResponseData and setResponseJSON so that the subclass
can change the responseData, and setResponseStatusCode:withHeaderFields:
so that it can change the response instance.  These are useful for
injecting mock responses or faults for testing.
