### PR TITLE
fixed warnings on XCode5

### DIFF
--- a/MKNetworkKit/Categories/NSData+MKBase64.m
+++ b/MKNetworkKit/Categories/NSData+MKBase64.m
@@ -101,7 +101,7 @@ void *mk_NewBase64Decode(
 		size_t accumulateIndex = 0;
 		while (i < length)
 		{
-			unsigned char decode = mk_base64DecodeLookup[inputBuffer[i++]];
+			unsigned char decode = mk_base64DecodeLookup[(int)inputBuffer[i++]];
 			if (decode != xx)
 			{
 				accumulated[accumulateIndex] = decode;

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -879,7 +879,7 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
 }
 
 #pragma mark -
-#pragma Main method
+#pragma mark Main method
 -(void) main {
   
   @autoreleasepool {
@@ -945,7 +945,7 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
   }
 }
 
-#pragma -
+#pragma mark -
 #pragma mark NSOperation stuff
 
 - (BOOL)isConcurrent


### PR DESCRIPTION
fixed some warnings
- MKNetworkOperation.m Unknown pragma ignored
- NSData+MKBase64.m Array subscript is of type 'char'
