### PR TITLE
Allow us to set the Queue length

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.h
+++ b/MKNetworkKit/MKNetworkEngine.h
@@ -253,6 +253,20 @@
 #endif
 
 /*!
+*  @abstract Set the max allowed network operations in the main queue
+*
+*/
+-(void)  setMaxConcurrentOperationCount:(int) ops;
+
+/*!
+* @abstract RESET the max allowed network operations in the main queue to defaults
+*  based on reachability
+*
+*/
+-(void)  resetMaxConcurrentOperationCount;
+
+
+/*!
  *  @abstract Enqueues your operation into the shared queue
  *  
  *  @discussion

--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -235,6 +235,28 @@ static NSOperationQueue *_sharedNetworkQueue;
   }
 }
 
+
+-(void) setMaxConcurrentOperationCount:(int) ops
+ {
+   if(ops != [_sharedNetworkQueue maxConcurrentOperationCount]){
+     [_sharedNetworkQueue setMaxConcurrentOperationCount:ops];
+   }
+ }
+ 
+ -(void) resetMaxConcurrentOperationCount
+ {
+   if([self.reachability currentReachabilityStatus] == ReachableViaWiFi)
+   {
+   [_sharedNetworkQueue setMaxConcurrentOperationCount:6];
+   }
+   else if([self.reachability currentReachabilityStatus] == ReachableViaWWAN)
+   {
+     [_sharedNetworkQueue setMaxConcurrentOperationCount:2];
+   }
+ }
+ 
+ 
+
 #pragma mark Freezing operations (Called when network connectivity fails)
 -(void) freezeOperations {
   
@@ -424,6 +446,7 @@ static NSOperationQueue *_sharedNetworkQueue;
   
   return nil;
 }
+
 
 -(void) enqueueOperation:(MKNetworkOperation*) operation {
   


### PR DESCRIPTION
A simple addition to allow the Queue length to be set regardless of interface.  For something, like downloading videos or other large files, a queue length of 6 is counter productive even on WiFi, so i would like to be able to set the number of simultaneous downloads.
