### PR TITLE
Fix logic around adding operations already in queue

### DIFF
--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -490,6 +490,7 @@ static NSOperationQueue *_sharedNetworkQueue;
         NSArray *operations = _sharedNetworkQueue.operations;
         NSUInteger index = [operations indexOfObject:operation];
         BOOL operationFinished = NO;
+        BOOL addOperation = NO;      
         if(index != NSNotFound) {
           
           MKNetworkOperation *queuedOperation = (MKNetworkOperation*) (operations)[index];
@@ -499,9 +500,12 @@ static NSOperationQueue *_sharedNetworkQueue;
               [queuedOperation updateHandlersFromOperation:operation];
             });
           }
+          addOperation = operationFinished;
+        } else {
+          addOperation = (expiryTimeInSeconds <= 0 || forceReload);
         }
         
-        if(expiryTimeInSeconds <= 0 || forceReload || operationFinished)
+        if(addOperation)
           [_sharedNetworkQueue addOperation:operation];
         // else don't do anything
       });


### PR DESCRIPTION
If an operation was enqueued that was already in the queue, there was logic in place to detect if it was already in the queue and add any new handlers to the existing one, but then the operation could be added to the queue anyway.  This could trigger an exception in NSOperationQueue.
