### PR TITLE
Added preprocessor check for iOS8 extensions

### DIFF
--- a/MKNetworkKit/Categories/UIAlertView+MKNetworkKitAdditions.m
+++ b/MKNetworkKit/Categories/UIAlertView+MKNetworkKitAdditions.m
@@ -23,6 +23,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 #if TARGET_OS_IPHONE
+#if !TARGET_IS_EXTENSION
 #import "UIAlertView+MKNetworkKitAdditions.h"
 
 @implementation UIAlertView (MKNetworkKitAdditions)
@@ -38,4 +39,5 @@
     return alert;
 }
 @end
+#endif
 #endif

--- a/MKNetworkKit/MKNetworkEngine.m
+++ b/MKNetworkKit/MKNetworkEngine.m
@@ -190,8 +190,10 @@ static NSOperationQueue *_sharedNetworkQueue;
     [[NSNotificationCenter defaultCenter] postNotificationName:kMKNetworkEngineOperationCountChanged
                                                         object:[NSNumber numberWithInteger:(NSInteger)[_sharedNetworkQueue operationCount]]];
 #if TARGET_OS_IPHONE
+#if !TARGET_IS_EXTENSION
     [UIApplication sharedApplication].networkActivityIndicatorVisible =
     ([_sharedNetworkQueue.operations count] > 0);
+#endif
 #endif
   }
   else {

--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -890,6 +890,7 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
 -(void) endBackgroundTask {
   
 #if TARGET_OS_IPHONE
+#if !TARGET_IS_EXTENSION
   dispatch_async(dispatch_get_main_queue(), ^{
     if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
       [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
@@ -897,12 +898,14 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
     }
   });
 #endif
+#endif
 }
 
 - (void) start
 {
   
 #if TARGET_OS_IPHONE
+#if !TARGET_IS_EXTENSION
   self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
     
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -915,6 +918,7 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,
     });
   }];
   
+#endif
 #endif
   
   if(!self.isCancelled) {
@@ -1482,6 +1486,7 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
 
 -(void) showLocalNotification {
 #if TARGET_OS_IPHONE
+#if !TARGET_IS_EXTENSION
   
   if(self.localNotification) {
     
@@ -1496,6 +1501,7 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
     [[UIApplication sharedApplication] presentLocalNotificationNow:localNotification];
   }
 #endif
+#endif
 }
 
 -(void) operationFailedWithError:(NSError*) error {
@@ -1509,8 +1515,10 @@ totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite {
     errorBlock(self, error);
   
 #if TARGET_OS_IPHONE
+#if !TARGET_IS_EXTENSION
   if([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground)
     [self showLocalNotification];
+#endif
 #endif
   
 }


### PR DESCRIPTION
Ive done a fix for this bug https://github.com/MugunthKumar/MKNetworkKit/issues/438

Got MKNetworkKit working in a Share Extension. A new preprocessor macro TARGET_IS_EXTENSION is needed to avoid calls to [UIApplication sharedApplication]

To set up with cocoa pods was a little tricky, on 'pod install' it'll create a separate pod target and add the preprocessor macro - podfile looks like this
```
link_with 'App', 'Extension'

pod 'MKNetworkKit'

target 'Extension' do
    post_install do |installer_representation|
        installer_representation.project.targets.each do |target|
            if target.name == 'Pods-Extension-MKNetworkKit'
                target.build_configurations.each do |config|
                    config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'TARGET_IS_EXTENSION=1']
                end
            end
        end
    end
end
```