### PR TITLE
sub-class type return

### DIFF
--- a/MKNetworkKit/MKNetworkHost.m
+++ b/MKNetworkKit/MKNetworkHost.m
@@ -140,9 +140,11 @@ NSString *const kMKCacheDefaultDirectoryName = @"com.mknetworkkit.mkcache";
 
 - (instancetype) initWithHostName:(NSString*) hostName {
   
-  MKNetworkHost *engine = [[MKNetworkHost alloc] init];
-  engine.hostName = hostName;
-  return engine;
+//  MKNetworkHost *engine = [[MKNetworkHost alloc] init];
+//  engine.hostName = hostName;
+    self = [self init];
+    self.hostName = hostName;
+    return self;
 }
 
 -(void) enableCache {


### PR DESCRIPTION
Hi.  When a sub-class inherits MKNetworkHost, I want to get sub-class type. But  initWithHostName:  returns the parent  class type. So I modify it.    